### PR TITLE
Add BSSID-triggered coffee event endpoint

### DIFF
--- a/internal/bssid/bssid.go
+++ b/internal/bssid/bssid.go
@@ -1,0 +1,85 @@
+// Package bssid provides a handler that creates coffee events based on BSSID proximity
+package bssid
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/baely/txn/internal/tracker/database"
+	"github.com/baely/txn/internal/tracker/models"
+)
+
+// Handler processes BSSID POST requests and creates coffee events when matched
+type Handler struct {
+	db          *database.Client
+	targetBSSID string
+	lastSeen    time.Time
+	mu          sync.Mutex
+	logger      *slog.Logger
+}
+
+// New creates a new Handler that reads the target BSSID from the COFFEE_BSSID env var
+func New(db *database.Client) *Handler {
+	return &Handler{
+		db:          db,
+		targetBSSID: os.Getenv("COFFEE_BSSID"),
+		logger:      slog.Default(),
+	}
+}
+
+// HandleBSSID processes a POST request containing a plaintext BSSID
+func (h *Handler) HandleBSSID(w http.ResponseWriter, r *http.Request) {
+	dump, err := httputil.DumpRequest(r, false)
+	if err != nil {
+		h.logger.Error("Failed to dump request", "error", err)
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	h.logger.Info(fmt.Sprintf("BSSID request:\n%s\nBody: %s", string(dump), string(body)))
+
+	bssid := strings.TrimSpace(string(body))
+
+	if !strings.EqualFold(bssid, h.targetBSSID) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	h.mu.Lock()
+	if time.Since(h.lastSeen) < 15*time.Minute {
+		h.lastSeen = time.Now()
+		h.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("debounced"))
+		return
+	}
+	h.lastSeen = time.Now()
+	h.mu.Unlock()
+
+	event := models.CaffeineEvent{
+		Timestamp:   time.Now(),
+		Description: "Atlassian Office Coffee",
+		Amount:      160,
+		Cost:        0,
+	}
+	if err := h.db.AddEvent(event); err != nil {
+		h.logger.Error("Failed to add coffee event", "error", err)
+		http.Error(w, "failed to create event", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.Info("Coffee event created", "bssid", bssid)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("created"))
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -76,6 +76,11 @@ func (t *TrackerService) Chi() chi.Router {
 	return t.router
 }
 
+// DB returns the database client for reuse by other packages
+func (t *TrackerService) DB() *database.Client {
+	return t.db
+}
+
 // HandleEvent processes transaction events from the webhook service
 // It implements the balance.TransactionEventHandler interface
 func (t *TrackerService) HandleEvent(event balance.TransactionEvent) error {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,10 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/baely/txn/internal/balance"
+	"github.com/baely/txn/internal/bssid"
 	"github.com/baely/txn/internal/common/errors"
 	"github.com/baely/txn/internal/common/logger"
 	"github.com/baely/txn/internal/ibbitot"
@@ -32,8 +35,12 @@ func main() {
 	webhookService.RegisterHandler(presenceService)
 	webhookService.RegisterHandler(trackerService)
 
-	// Register domain handlers
-	s.RegisterDomain("events.baileys.dev", webhookService.Chi())
+	// Build combined router for events domain
+	bssidHandler := bssid.New(trackerService.DB())
+	eventsRouter := chi.NewRouter()
+	eventsRouter.Mount("/", webhookService.Chi())
+	eventsRouter.Post("/bssid", bssidHandler.HandleBSSID)
+	s.RegisterDomain("events.baileys.dev", eventsRouter)
 	s.RegisterDomain("isbaileybutlerintheoffice.today", presenceService.Chi())
 	s.RegisterDomain("baileyneeds.coffee", trackerService.Chi())
 	s.RegisterDomain("caffeine-api.baileys.dev", trackerService.Chi())


### PR DESCRIPTION
## Summary
- New `POST /bssid` endpoint on `events.baileys.dev` that creates a coffee event when the posted BSSID matches the `COFFEE_BSSID` env var
- Events are debounced (15 min) to avoid duplicates
- Includes full request dump logging for debugging

## Test plan
- [ ] Set `COFFEE_BSSID` env var and POST matching/non-matching BSSIDs
- [ ] Verify debounce: second request within 15 min returns "debounced"
- [ ] Verify event is created in the database with correct values (160mg, cost 0)
- [ ] Check logs for request dump output

🤖 Generated with [Claude Code](https://claude.com/claude-code)